### PR TITLE
print empty string instead of exception message

### DIFF
--- a/src/TranslatedField.php
+++ b/src/TranslatedField.php
@@ -22,7 +22,7 @@ class TranslatedField implements JsonSerializable, ArrayAccess
         try {
             return $this->get();
         } catch (\Exception $e) {
-            return 'Exception: '.$e->getMessage();
+            return '';
         }
     }
 


### PR DESCRIPTION
When the translated field is falsy, we don't have to check:
* if the translated field is null
* if the offset exist
* if the value associated is not null